### PR TITLE
Windows support

### DIFF
--- a/include/Allocator.hpp
+++ b/include/Allocator.hpp
@@ -69,7 +69,20 @@ namespace impl {
         static_assert( is_power_of_two(alignment),
                 "alignment is not a power of two");
         void *ptr;
-        int result = posix_memalign(&ptr, alignment, size*sizeof(T));
+        int result;
+
+#ifdef  _MSC_VER 
+            ptr = _aligned_malloc(size * sizeof(T), alignment);
+            if (ptr == NULL) {
+                result = 1;
+            }
+            else {
+                result = 0;
+            }
+#else 
+            result = posix_memalign(&ptr, alignment, size*sizeof(T));
+#endif
+
         if(result) {
             return nullptr;
         }
@@ -84,7 +97,12 @@ namespace impl {
         }
 
         void free_policy(void *ptr) {
+#ifdef      _MSC_VER 
+                _aligned_free(ptr);
+#else
             free(ptr);
+#endif
+
         }
 
         static constexpr size_type alignment() {

--- a/include/ArrayView.hpp
+++ b/include/ArrayView.hpp
@@ -660,13 +660,13 @@ public:
         typename Other,
         typename = typename std::enable_if< impl::is_array<Other>::value >::type
     >
-    ArrayReference operator = (Other&& other) {
+    ArrayReference& operator = (Other&& other) {
 #ifndef NDEBUG
         assert(other.size() == this->size());
 #endif
 #ifdef VERBOSE
         std::cerr << util::type_printer<ArrayReference>::print()
-                  << "::" << util::blue("operator=") << "(&&"
+                  << "::" << util::blue("operator=") << "(generic &&"
                   << util::type_printer<typename std::decay<Other>::type>::print()
                   << ")" << std::endl;
 #endif

--- a/include/ArrayView.hpp
+++ b/include/ArrayView.hpp
@@ -675,6 +675,22 @@ public:
         return *this;
     }
 
+
+    ArrayReference& operator = (const ArrayReference& other) {
+#ifndef ndebug
+        assert(other.size() == this->size());
+#endif
+#ifdef verbose
+        std::cerr << util::type_printer<arrayreference>::print()
+            << "::" << util::blue("operator=") << "(&&"
+            << util::type_printer<typename std::decay<other>::type>::print()
+            << ")" << std::endl;
+#endif
+        base::coordinator_.copy(other, *this);
+
+        return *this;
+    }
+
     ArrayReference& operator = (value_type value) {
 #ifdef VERBOSE
         std::cerr << util::pretty_printer<ArrayReference>::print(*this)

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -58,7 +58,6 @@ std::string to_string(T val) {
 enum stringColor {kWhite, kRed, kGreen, kBlue, kYellow, kPurple, kCyan};
 
 #ifdef COLOR_PRINTING
-__attribute__((unused))
 static std::string colorize(std::string const& s, stringColor c) {
     switch(c) {
         case kWhite :
@@ -80,38 +79,37 @@ static std::string colorize(std::string const& s, stringColor c) {
     return s;
 }
 #else
-__attribute__((unused))
 static std::string colorize(std::string const& s, stringColor c) {
     return s;
 }
 #endif
 
 // helpers for inline printing
-__attribute__((unused))
+ 
 static std::string red(std::string const& s) {
     return colorize(s, kRed);
 }
-__attribute__((unused))
+ 
 static std::string green(std::string const& s) {
     return colorize(s, kGreen);
 }
-__attribute__((unused))
+ 
 static std::string yellow(std::string const& s) {
     return colorize(s, kYellow);
 }
-__attribute__((unused))
+ 
 static std::string blue(std::string const& s) {
     return colorize(s, kBlue);
 }
-__attribute__((unused))
+ 
 static std::string purple(std::string const& s) {
     return colorize(s, kPurple);
 }
-__attribute__((unused))
+ 
 static std::string cyan(std::string const& s) {
     return colorize(s, kCyan);
 }
-__attribute__((unused))
+ 
 static std::string white(std::string const& s) {
     return colorize(s, kWhite);
 }

--- a/tests/allocator_unittest.cpp
+++ b/tests/allocator_unittest.cpp
@@ -12,14 +12,24 @@ struct packer {
 TEST(Allocator, minimum_possible_alignment) {
     using namespace memory::impl;
     size_t tmp;
+
+    //Smallest allignment in visual studio is 4 (using _aligned_malloc)
+    int smallest_allignment;
+#ifdef  _MSC_VER 
+    smallest_allignment = 4;
+#else 
+    smallest_allignment = 8;
+#endif
+
+
     tmp = minimum_possible_alignment< packer<1> >();
-    EXPECT_EQ(tmp,8);
+    EXPECT_EQ(tmp, smallest_allignment);
     tmp = minimum_possible_alignment< packer<2> >();
-    EXPECT_EQ(tmp,8);
+    EXPECT_EQ(tmp, smallest_allignment);
     tmp = minimum_possible_alignment< packer<3> >();
-    EXPECT_EQ(tmp,8);
+    EXPECT_EQ(tmp, smallest_allignment);
     tmp = minimum_possible_alignment< packer<4> >();
-    EXPECT_EQ(tmp,8);
+    EXPECT_EQ(tmp, smallest_allignment);
     tmp = minimum_possible_alignment< packer<5> >();
     EXPECT_EQ(tmp,8);
     tmp = minimum_possible_alignment< packer<6> >();

--- a/tests/array_reference_unittest.cpp
+++ b/tests/array_reference_unittest.cpp
@@ -24,7 +24,7 @@ TEST(ArrayReference, basics) {
     for(auto i=0; i<5; ++i)
         EXPECT_EQ(v1[i], 1.);
     vr2 = vr1;
-    EXPECT_EQ(v1.data(), vr2.data());
+    //EXPECT_EQ(v1.data(), vr2.data());
     for(auto i=5; i<10; ++i)
         EXPECT_EQ(v1[i], 1.);
 

--- a/tests/array_reference_unittest.cpp
+++ b/tests/array_reference_unittest.cpp
@@ -24,7 +24,6 @@ TEST(ArrayReference, basics) {
     for(auto i=0; i<5; ++i)
         EXPECT_EQ(v1[i], 1.);
     vr2 = vr1;
-    //EXPECT_EQ(v1.data(), vr2.data());
     for(auto i=5; i<10; ++i)
         EXPECT_EQ(v1[i], 1.);
 

--- a/tests/array_reference_unittest.cpp
+++ b/tests/array_reference_unittest.cpp
@@ -24,6 +24,7 @@ TEST(ArrayReference, basics) {
     for(auto i=0; i<5; ++i)
         EXPECT_EQ(v1[i], 1.);
     vr2 = vr1;
+    EXPECT_EQ(v1.data(), vr2.data());
     for(auto i=5; i<10; ++i)
         EXPECT_EQ(v1[i], 1.);
 

--- a/tests/array_view_unittest.cpp
+++ b/tests/array_view_unittest.cpp
@@ -1,6 +1,7 @@
 #include "gtest.h"
 
 #include <Vector.hpp>
+#include <numeric>
 
 // check that const views work
 TEST(array_view, const_view) {

--- a/tests/host_vector_unittest.cpp
+++ b/tests/host_vector_unittest.cpp
@@ -5,6 +5,7 @@
 
 #include <Vector.hpp>
 #include <HostCoordinator.hpp>
+#include <numeric>
 
 template <typename VEC>
 void print(VEC const& v) {


### PR DESCRIPTION
All changes needed for green light without warning in the build in visual studio 2015

Additional operator () with ifdef guard for windows   // If you have a better solution..
CMakefile with visual studio specific compiler flags
Added additional ifdefs around gnu specific code.
